### PR TITLE
Fix node 24 compatibility (by using node-abi 4.11.0)

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,11 @@
     "bindings": "^1.5.0",
     "prebuild-install": "^7.1.1"
   },
+  "overrides": {
+    "prebuild": {
+      "node-abi": "4.9.0"
+    }
+  },
   "devDependencies": {
     "chai": "^4.3.8",
     "cli-color": "^2.0.3",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "overrides": {
     "prebuild": {
-      "node-abi": "4.9.0"
+      "node-abi": "4.11.0"
     }
   },
   "devDependencies": {


### PR DESCRIPTION
This forces `prebuild` to use `node-abi` v4.11.0. 

In older versions of `node-abi`, node 24 resolved to ABI v134, which was the pre-release version. This causes the prebuilds for node 24 to be published under ABI v134, meaning they're not resolved when building under ABI v137. This made the issue described [here](https://discord.com/channels/830183651022471199/1382637395740069919) appear for me again.

These changes are already made upstream: https://github.com/WiseLibs/better-sqlite3/pull/1385