### PR TITLE
ci: publish @rocicorp/zero-sqlite3 via OIDC (drop NPM_TOKEN)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -142,8 +142,6 @@ jobs:
       - name: Upgrade npm for OIDC support
         run: npm install -g npm@latest
       - run: npm publish --provenance
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   prebuild:
     if: ${{ github.event_name == 'release' }}


### PR DESCRIPTION
## ✅ Safe to merge — npm Trusted Publisher is configured

The \`publish\` job already has job-scoped \`id-token: write\` + \`npm install -g npm@latest\` + \`if: release\`, but still passed \`NODE_AUTH_TOKEN: secrets.NPM_TOKEN\`. With a token present, npm uses **token auth and ignores OIDC**, leaving the long-lived token able to publish.

This PR removes the \`env: NODE_AUTH_TOKEN\` so npm authenticates via the **OIDC Trusted Publisher**.

### Sequencing
1. ✅ **Done** — npm Trusted Publisher for \`@rocicorp/zero-sqlite3\` configured (\`rocicorp/zero-sqlite3\` + \`build.yml\`, no environment).
2. ⏭️ Merge this PR once the test matrix is green.
3. ⏭️ Cut a release; confirm publish authenticates via OIDC + provenance.
4. ⏭️ npmjs.com → Publishing access → **Require 2FA and disallow tokens**; revoke the \`NPM_TOKEN\` (npm token + repo secret).

Note: the \`publish\` job is \`if: github.event_name == 'release'\`, so PR CI does not exercise the auth change — it is validated on the next actual release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)