### PR TITLE
ci: harden .npmrc (release-age cooldown + block git-URL deps)

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -4,3 +4,9 @@ package-lock=false
 # so freshly-compromised releases are likely caught/yanked before we pull them.
 # https://snyk.io/blog/tanstack-npm-packages-compromised/
 min-release-age=7
+
+# Block git-URL dependencies entirely (npm CLI v11.10+). Git deps can ship
+# their own .npmrc and override the git executable path, enabling arbitrary
+# code execution during install (the actual TanStack attack vector). No
+# current dep needs this and npm v12 is expected to make none the default.
+allow-git=none

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,6 @@
 package-lock=false
+
+# Supply-chain hardening: only install npm versions published >=7 days ago,
+# so freshly-compromised releases are likely caught/yanked before we pull them.
+# https://snyk.io/blog/tanstack-npm-packages-compromised/
+min-release-age=7


### PR DESCRIPTION
Two related Step-6 npm-rc hardenings (Snyk / TanStack supply-chain advisory):

1. **\`min-release-age=7\`** — only install npm versions published ≥7 days ago, so freshly-compromised releases are likely caught/yanked first. With \`package-lock=false\` already set, this gates every \`npm install\` resolve.
2. **\`allow-git=none\`** — block git-URL dependencies entirely. Git deps can ship a \`.npmrc\` that overrides the git executable path → arbitrary code execution at install (the actual TanStack vector). Supported since npm CLI 11.10; expected to be the default in npm v12. **Audited the org: no repo has a git-URL dep**, so this is a pure no-regret going-forward control.

Neither setting needs an exclude here; if a temporary bypass is ever needed, override per-invocation (e.g. \`npm install --allow-git=all\`).

CI already runs \`npm install --ignore-scripts\` (the other Step-6 tip).

Note: npm has no per-package exclude for \`min-release-age\`. zero-sqlite3 has very few deps so the risk of needing a <7-day-old version is low.

🤖 Generated with [Claude Code](https://claude.com/claude-code)