### PR TITLE
ci: fix bump-version workflow (GITHUB_TOKEN, push to main)

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -16,10 +16,15 @@ jobs:
   bump:
     name: Bump to a new version
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # Required to push the version commit and tag.
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          token: ${{ secrets.PAT }}
+          # Use the built-in GITHUB_TOKEN (no PAT secret needed). Note: pushes
+          # made with GITHUB_TOKEN do not trigger further workflows, so the
+          # release that publishes to npm must still be created manually (which
+          # fires the `release` event that the publish job listens for).
           fetch-depth: 0
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
@@ -31,6 +36,6 @@ jobs:
       - name: Bump the version
         run: npm version ${{ github.event.inputs.type }}
       - name: Push commit
-        run: git push origin master:master
+        run: git push origin HEAD:main
       - name: Push tag
         run: git push origin --tags


### PR DESCRIPTION
## Problem

The `bump-version` workflow [failed at checkout](https://github.com/rocicorp/zero-sqlite3/actions/runs/26765496850/job/78890623743) with:

```
##[error]Input required and not supplied: token
```

Two bugs inherited from the upstream `better-sqlite3` fork:

1. `actions/checkout` used `token: ${{ secrets.PAT }}`, but **no `PAT` secret is configured** in this repo (the repo has no secrets at all since the switch to OIDC trusted publishing). The empty token made checkout fail.
2. The push targeted `master:master`, but this repo's default branch is **`main`**.

## Fix

- Drop the PAT requirement: use the built-in `GITHUB_TOKEN` with `permissions: contents: write`.
- Push the version commit to `main` (was `master`).

## Release flow note

Pushes made with `GITHUB_TOKEN` intentionally **do not trigger downstream workflows**, so this job only bumps the version + pushes the tag. To publish to npm (with provenance), create a GitHub **Release** from the new tag — that fires the `release` event the `publish` job listens for (`npm publish --provenance`).

If you'd prefer the bump to *auto-create* the release and trigger publish end-to-end, that needs a PAT or GitHub App token (GITHUB_TOKEN can't cascade) — happy to wire that up as a follow-up.

> [!NOTE]
> If `main` is a protected branch requiring PRs, the direct push from this job will be rejected; that's a repo-settings consideration, not a workflow one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)