### PR TITLE
ci: trigger release on version tag push (v*)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,12 +4,11 @@ on:
   push:
     branches:
       - main
+    tags:
+      - 'v*'
   pull_request:
     branches:
       - main
-  release:
-    types:
-      - released
   workflow_dispatch: {}
 
 env:
@@ -119,7 +118,7 @@ jobs:
           bun shell.js --version
 
   publish:
-    if: ${{ github.event_name == 'release' }}
+    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
     name: Publishing to NPM
     runs-on: ubuntu-22.04
     permissions:
@@ -144,7 +143,9 @@ jobs:
       - run: npm publish --provenance
 
   prebuild:
-    if: ${{ github.event_name == 'release' }}
+    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+    permissions:
+      contents: write # prebuild -u creates the GitHub release and uploads .node assets
     strategy:
       fail-fast: false
       matrix:
@@ -175,7 +176,9 @@ jobs:
           ${{ env.NODE_BUILD_CMD_MODERN }} --arch arm64 -u ${{ secrets.GITHUB_TOKEN }}
 
   prebuild-linux-x64:
-    if: ${{ github.event_name == 'release' }}
+    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+    permissions:
+      contents: write # prebuild -u creates the GitHub release and uploads .node assets
     name: Prebuild on Linux x64
     runs-on: ubuntu-latest
     container: node:20-bullseye
@@ -187,7 +190,9 @@ jobs:
       - run: ${{ env.NODE_BUILD_CMD_LEGACY }} -u ${{ secrets.GITHUB_TOKEN }}
 
   prebuild-linux-x64-node-modern:
-    if: ${{ github.event_name == 'release' }}
+    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+    permissions:
+      contents: write # prebuild -u creates the GitHub release and uploads .node assets
     name: Prebuild on Linux x64 (Node 25+)
     runs-on: ubuntu-latest
     container: node:20-bookworm
@@ -199,7 +204,9 @@ jobs:
       - run: ${{ env.NODE_BUILD_CMD_MODERN }} -u ${{ secrets.GITHUB_TOKEN }}
 
   prebuild-alpine:
-    if: ${{ github.event_name == 'release' }}
+    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+    permissions:
+      contents: write # prebuild -u creates the GitHub release and uploads .node assets
     name: Prebuild on alpine
     runs-on: ubuntu-latest
     container: node:20-alpine
@@ -212,7 +219,9 @@ jobs:
       - run: ${{ env.NODE_BUILD_CMD_MODERN }} -u ${{ secrets.GITHUB_TOKEN }}
 
   prebuild-alpine-arm:
-    if: ${{ github.event_name == 'release' }}
+    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+    permissions:
+      contents: write # prebuild -u creates the GitHub release and uploads .node assets
     strategy:
       fail-fast: false
       matrix:
@@ -234,7 +243,9 @@ jobs:
           ${{ env.NODE_BUILD_CMD_MODERN }} -u ${{ secrets.GITHUB_TOKEN }}"
 
   prebuild-linux-arm:
-    if: ${{ github.event_name == 'release' }}
+    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+    permissions:
+      contents: write # prebuild -u creates the GitHub release and uploads .node assets
     strategy:
       fail-fast: false
       matrix:
@@ -255,7 +266,9 @@ jobs:
           ${{ env.NODE_BUILD_CMD_LEGACY }} -u ${{ secrets.GITHUB_TOKEN }}"
 
   prebuild-linux-arm-node-modern:
-    if: ${{ github.event_name == 'release' }}
+    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+    permissions:
+      contents: write # prebuild -u creates the GitHub release and uploads .node assets
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## What

Make the release pipeline run when a **`v*` tag is pushed**, so the manual flow `npm version <type>` + `git push --tags` cuts a release (npm publish with provenance + prebuilt binaries).

## Changes

- `on:` — add `push.tags: ['v*']`; **remove** the `release` trigger.
- `publish` + all `prebuild*` jobs — gate on `startsWith(github.ref, 'refs/tags/v')` instead of `github.event_name == 'release'`.
- `prebuild*` jobs — add `permissions: contents: write`. `prebuild -u` **creates the GitHub release and uploads the `.node` assets** (see `prebuild/upload.js`), which needs write access; this repo's default workflow token is read-only.
- `publish` keeps `id-token: write` for OIDC provenance.

## Release flow after this merges

> [!IMPORTANT]
> A tag only triggers the workflow version present at the tagged commit, so **this must be on `main` before a tag push will do anything.**

Then, to cut a release:
```bash
git checkout main && git pull
npm version minor        # bumps package.json, commits, tags vX.Y.Z
git push origin vX.Y.Z   # tag push triggers test → prebuild → publish
```

`main` is protected (PRs only), so the bump **commit** can't be pushed to `main` directly — only the tag. The publish job checks out the tag, so the published version is correct; `main`'s `package.json` can be synced with a follow-up PR (or do the bump via PR first, then tag the merged commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)