### PR TITLE
ci: give prebuild jobs contents:write so release uploads work

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -145,6 +145,8 @@ jobs:
 
   prebuild:
     if: ${{ github.event_name == 'release' }}
+    permissions:
+      contents: write # prebuild -u uploads the .node assets to the GitHub release
     strategy:
       fail-fast: false
       matrix:
@@ -176,6 +178,8 @@ jobs:
 
   prebuild-linux-x64:
     if: ${{ github.event_name == 'release' }}
+    permissions:
+      contents: write # prebuild -u uploads the .node assets to the GitHub release
     name: Prebuild on Linux x64
     runs-on: ubuntu-latest
     container: node:20-bullseye
@@ -188,6 +192,8 @@ jobs:
 
   prebuild-linux-x64-node-modern:
     if: ${{ github.event_name == 'release' }}
+    permissions:
+      contents: write # prebuild -u uploads the .node assets to the GitHub release
     name: Prebuild on Linux x64 (Node 25+)
     runs-on: ubuntu-latest
     container: node:20-bookworm
@@ -200,6 +206,8 @@ jobs:
 
   prebuild-alpine:
     if: ${{ github.event_name == 'release' }}
+    permissions:
+      contents: write # prebuild -u uploads the .node assets to the GitHub release
     name: Prebuild on alpine
     runs-on: ubuntu-latest
     container: node:20-alpine
@@ -213,6 +221,8 @@ jobs:
 
   prebuild-alpine-arm:
     if: ${{ github.event_name == 'release' }}
+    permissions:
+      contents: write # prebuild -u uploads the .node assets to the GitHub release
     strategy:
       fail-fast: false
       matrix:
@@ -235,6 +245,8 @@ jobs:
 
   prebuild-linux-arm:
     if: ${{ github.event_name == 'release' }}
+    permissions:
+      contents: write # prebuild -u uploads the .node assets to the GitHub release
     strategy:
       fail-fast: false
       matrix:
@@ -256,6 +268,8 @@ jobs:
 
   prebuild-linux-arm-node-modern:
     if: ${{ github.event_name == 'release' }}
+    permissions:
+      contents: write # prebuild -u uploads the .node assets to the GitHub release
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Problem

The `prebuild*` jobs run `prebuild -u $GITHUB_TOKEN`, which **uploads the built `.node` binaries to the GitHub Release**. Uploading release assets requires `contents: write`, but this repo's default workflow token is **read-only** (`default_workflow_permissions: read`). On the first real release the uploads would **403**, and consumers' `prebuild-install` would find no prebuilt binaries (forcing a source build, which now also needs ICU).

## Fix

Add `permissions: contents: write` to each of the 7 prebuild jobs. That's the whole change.

- **No trigger change** — releases are still cut via the `release` event (manual `npm version` → push tag → publish a GitHub Release → build).
- `publish` already has the permissions it needs (`id-token: write` for OIDC provenance).

```
+    permissions:
+      contents: write # prebuild -u uploads the .node assets to the GitHub release
```
×7 (prebuild, prebuild-linux-x64, -x64-node-modern, -alpine, -alpine-arm, -linux-arm, -linux-arm-node-modern)

🤖 Generated with [Claude Code](https://claude.com/claude-code)