### PR TITLE
fix: link ICU dynamically on Alpine (musl static ICU is non-PIC)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -214,7 +214,7 @@ jobs:
     needs: test
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - run: apk add build-base git python3 py3-setuptools libstdc++ readline-dev ncurses-dev icu-dev icu-static --update-cache
+      - run: apk add build-base git python3 py3-setuptools libstdc++ readline-dev ncurses-dev icu-dev --update-cache
       - run: npm install --ignore-scripts
       - run: ${{ env.NODE_BUILD_CMD_LEGACY }} -u ${{ secrets.GITHUB_TOKEN }}
       - run: ${{ env.NODE_BUILD_CMD_MODERN }} -u ${{ secrets.GITHUB_TOKEN }}
@@ -237,7 +237,7 @@ jobs:
       - uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
       - run: |
           docker run --rm -v $(pwd):/tmp/project --entrypoint /bin/sh --platform linux/${{ matrix.arch }} node:20-alpine -c "\
-          apk add build-base git python3 py3-setuptools libstdc++ readline-dev ncurses-dev icu-dev icu-static --update-cache && \
+          apk add build-base git python3 py3-setuptools libstdc++ readline-dev ncurses-dev icu-dev --update-cache && \
           cd /tmp/project && \
           npm install --ignore-scripts && \
           ${{ env.NODE_BUILD_CMD_LEGACY }} -u ${{ secrets.GITHUB_TOKEN }} && \

--- a/deps/icu.js
+++ b/deps/icu.js
@@ -8,14 +8,14 @@
 // auto-registers Unicode-aware LIKE/upper()/lower()/REGEXP on every
 // connection. That code calls into ICU.
 //
-// We prefer STATIC linking so the prebuilt .node binaries stay self-contained:
-// zero-cache ships them via prebuild-install onto runtime images (e.g. Alpine)
-// that do not have ICU installed, and a dynamic NEEDED libicu*.so.<ver> would
-// fail to load there. Static linking is only possible where the ICU archives
-// are -fPIC, which holds on macOS (Homebrew) and Alpine (musl). Debian/Ubuntu
-// (glibc) ship non-PIC static archives, so there we link ICU dynamically
-// against the system .so (the consumer must have ICU installed at runtime).
-// See `useStatic` below.
+// We STATIC-link ICU where we can, so the prebuilt .node stays self-contained.
+// That is only possible where the ICU static archives are position-independent
+// (-fPIC) and can be linked into a shared object (the .node) — which in practice
+// is ONLY macOS (Homebrew). Both Linux flavors ship NON-PIC static archives:
+// Debian/Ubuntu (glibc) AND Alpine (musl) both fail with "recompile with -fPIC".
+// So on every Linux we link ICU dynamically against the system .so, and the
+// consumer must have ICU installed at runtime (e.g. `apk add icu-libs` in the
+// zero-cache Alpine image). See `useStatic` below.
 //
 // Usage:
 //   node icu.js include   -> the ICU include directory (for #include <unicode/...>)
@@ -23,9 +23,8 @@
 //                             paths or -L/-l flags), then the C++ runtime /
 //                             system libraries ICU depends on.
 //
-// Discovery order: pkg-config (Linux/Alpine) -> Homebrew icu4c (macOS) ->
-// common system locations. Set ICU_ROOT to override (expects ICU_ROOT/lib and
-// ICU_ROOT/include).
+// Discovery order: pkg-config (Linux) -> Homebrew icu4c (macOS) -> common system
+// locations. Set ICU_ROOT to override (expects ICU_ROOT/lib and ICU_ROOT/include).
 //
 // ICU is not enabled on Windows (see deps/sqlite3.gyp), so this script only
 // ever runs on macOS and Linux.
@@ -36,20 +35,15 @@ const fs = require('fs');
 const path = require('path');
 
 const isMac = process.platform === 'darwin';
-const isLinux = process.platform === 'linux';
-const isAlpine = isLinux && fs.existsSync('/etc/alpine-release');
 
-// We static-link ICU only where the static archives are position-independent
-// (-fPIC) and can therefore be linked into a shared object (the .node):
-//   * macOS  — Homebrew's icu4c archives are PIC.
-//   * Alpine — musl builds everything PIC, so icu-static is PIC.
-// Debian/Ubuntu (glibc) ship NON-PIC static archives (libicu*.a), which fail to
-// link into a shared object ("recompile with -fPIC"), so on glibc Linux we link
-// ICU dynamically against the distro .so instead — those consumers must have
-// ICU installed at runtime. ICU_ALLOW_DYNAMIC=1 forces dynamic everywhere as a
-// local-dev escape hatch.
-const useStatic =
-  (isMac || isAlpine) && process.env.ICU_ALLOW_DYNAMIC !== '1';
+// Static-link ICU only on macOS, the one platform whose static archives are
+// -fPIC and so can be linked into the .node shared object. Both Debian/Ubuntu
+// (glibc) and Alpine (musl) ship NON-PIC static archives (libicu*.a) that fail
+// with "relocation ... can not be used when making a shared object; recompile
+// with -fPIC", so on all Linux we link ICU dynamically against the system .so
+// and the consumer must have ICU at runtime. ICU_ALLOW_DYNAMIC=1 forces dynamic
+// even on macOS, as a local-dev escape hatch.
+const useStatic = isMac && process.env.ICU_ALLOW_DYNAMIC !== '1';
 
 function run(cmd) {
   try {
@@ -125,15 +119,14 @@ function staticLibInputs(loc) {
     if (full && fs.existsSync(full)) {
       return full;
     }
-    // On the static platforms (macOS, Alpine) a missing archive is fatal: we
-    // must not silently produce a dynamically-linked binary, since zero-cache
-    // ships these prebuilds onto images (e.g. Alpine) that have no ICU.
+    // macOS is the only static platform; a missing archive is fatal here (we
+    // must not silently fall back to a dynamic build that would change the
+    // shipped binary's behavior).
     fail(
       `static ICU archive ${name}.a not found in ${loc.libDir || '(unknown library dir)'}.\n` +
-        `  This platform links ICU statically to stay self-contained, so the build is aborting\n` +
-        `  rather than linking ICU dynamically. Install the static ICU libraries (icu-dev +\n` +
-        `  icu-static on Alpine, icu4c via Homebrew on macOS), or set ICU_ALLOW_DYNAMIC=1 to\n` +
-        `  allow a dynamic fallback for local development.`,
+        `  macOS links ICU statically to stay self-contained, so the build is aborting rather\n` +
+        `  than linking ICU dynamically. Install icu4c via Homebrew (brew install icu4c), or\n` +
+        `  set ICU_ALLOW_DYNAMIC=1 to allow a dynamic fallback for local development.`,
     );
     return null; // unreachable; fail() exits
   });


### PR DESCRIPTION
## Problem

The **Alpine prebuild fails to link** with:

```
/usr/lib/libicuuc.a(putil.ao): relocation R_X86_64_PC32 against symbol `tzname'
can not be used when making a shared object; recompile with -fPIC
```

Alpine's `icu-static` is **not** built with `-fPIC`, so it can't be linked into the `.node` shared object — the same wall glibc hit. (Correcting an earlier wrong assumption that musl static archives are PIC.)

**Static ICU only works on macOS.** Both glibc and musl ship non-PIC static archives.

## Fix

Link ICU **dynamically on all Linux** (glibc + Alpine); keep static on macOS.

- `deps/icu.js`: `useStatic = isMac` only (drop the Alpine static branch).
- `build.yml`: drop `icu-static` from the alpine prebuild apk installs — `icu-dev` provides the headers and the `.so` we now link against.

Verified macOS still static-links and stays self-contained (`otool -L` shows no ICU).

## ⚠️ Runtime requirement (action needed in the image repo)

The Alpine `.node` now has a `NEEDED libicu*.so.<ver>`, so the **zero-cache Alpine runtime image must install ICU**:

```dockerfile
RUN apk add --no-cache icu-libs
```

Without it, loading `@rocicorp/zero-sqlite3` will fail at runtime on Alpine. (Couples to the ICU soname/major in the build image — currently Alpine `icu 76`.)

## Note on the in-flight v1.1.0 release

`v1.1.0` was cut before this fix, so its Alpine prebuild failed and `npm publish` never ran (npm is still on 1.0.18). This fix needs to be on `main` and in a **new tag** (e.g. re-cut after merge) for the release to complete cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)