### PR TITLE
ci: test only the maintained LTS Node lines (22, 24)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,11 +31,8 @@ jobs:
           - macos-15-intel
           - windows-2022
         node:
-          - 20
           - 22
-          - 23
           - 24
-          - 25
     name: Testing Node ${{ matrix.node }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     steps:

--- a/README.md
+++ b/README.md
@@ -4,6 +4,6 @@ So far the changes are:
 
 * Build the [bedrock](https://sqlite.org/src/timeline?r=bedrock) branch of SQLite to enable [`begin concurrent`](https://www.sqlite.org/src/doc/begin-concurrent/doc/begin_concurrent.md).
 * Create a shell too, so we can debug db files created
-* Supports both Node.js (20.x, 22.x, 23.x, 24.x) and Bun (>=1.1.0) runtimes
+* Supports both Node.js (22.x, 24.x) and Bun (>=1.1.0) runtimes
 
 Other changes will be likely be made over time.

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "shell.js"
   ],
   "engines": {
-    "node": "20.x || 22.x || 23.x || 24.x || 25.x",
+    "node": "22.x || 24.x",
     "bun": ">=1.1.0"
   },
   "types": "lib/index.d.ts",


### PR DESCRIPTION
Foundational cleanup so the option-C work (#38) rests on a sane, Node-24-anchored base.

## Why
The test matrix carried **three EOL Node versions** (as of today):
- Node **20** — EOL 2026-04-30
- Node **23** — EOL 2025-06-01
- Node **25** — EOL 2026-06-01

Only **22** and **24** are maintained LTS lines (22 → 2027, 24 → 2028).

## What
- Test matrix: `[20, 22, 23, 24, 25]` → `[22, 24]`.
- `engines`: `20.x || 22.x || 23.x || 24.x || 25.x` → `22.x || 24.x`.
- README runtime list updated.
- **Node 24 is the canonical anchor** (Unicode 17) — used to generate/verify the bundled Unicode case table in #38.

## Scope
Deliberately minimal: this is the *supported-versions declaration* only. **Prebuild ABI targets are untouched** to avoid overlapping #37 (native arm64 builders), which restructures the prebuild jobs. Aligning the prebuild targets to 22/24 (and dropping the now-unused "modern"/bookworm path) is a clean follow-up once #37 lands.

After this merges, #38 (option C) rebases on top — its Unicode-version-gated tests then sit on a matrix where Node 24 is the clear anchor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)