### PR TITLE
1.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocicorp/zero-sqlite3",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "better-sqlite3 on bedrock",
   "homepage": "https://github.com/rocicorp/zero-sqlite3",
   "author": "Rocicorp",


### PR DESCRIPTION
Release bump to **1.1.2**.

Ships the upstream `wise/master` sync merged in #42:
- `SQLITE_ENABLE_PERCENTILE` — `percentile()`/`median()` SQL functions
- Node 26 support (macOS/Linux test + prebuilds)
- mocha → 11 (Node 26 compatibility)

Our begin-concurrent SQLite 3.51.0 checkin, electron-disabled build, and `@rocicorp` versioning are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)