### PR TITLE
fix: publish complete release packages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -154,7 +154,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
-          node-version: 20
+          node-version: 24.15.0
           registry-url: https://registry.npmjs.org
       - name: Collect prebuilds from all platforms
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "files": [
     "binding.gyp",
-    "src/**/*.[ch]pp",
+    "src/**/*.{c,cc,cpp,h,hpp}",
     "lib/**",
     "deps/**",
     "prebuilds/**",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocicorp/zero-sqlite3",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "better-sqlite3 on bedrock",
   "homepage": "https://github.com/rocicorp/zero-sqlite3",
   "author": "Rocicorp",


### PR DESCRIPTION
Fix the release packaging path so published releases include all prebuilt binaries and can fall back to a source build.

- publish with Node 24.15.0, which supports the current npm version required for provenance publishing
- include C/C++ headers in the npm tarball, including unicode_case_data.h
- bump to 1.1.4

Verified with npm pack --dry-run that the package includes src/util/unicode_case_data.h.